### PR TITLE
Advanced create dataset

### DIFF
--- a/client.go
+++ b/client.go
@@ -57,6 +57,8 @@ type Client struct {
 	maximumSize json.Number
 }
 
+var _ Clientable = &Client{}
+
 // NewClient creates a wrapper over http.Client to communicate with the flocker control service.
 func NewClient(host string, port int, clientIP string, caCertPath, keyPath, certPath string) (*Client, error) {
 	client, err := newTLSClient(caCertPath, keyPath, certPath)

--- a/client_test.go
+++ b/client_test.go
@@ -288,10 +288,6 @@ func TestUpdatePrimaryForDataset(t *testing.T) {
 	assert.NotEqual("", s.Path)
 }
 
-func TestInterfaceIsImplemented(t *testing.T) {
-	assert.Implements(t, (*Clientable)(nil), Client{})
-}
-
 func newFlockerTestClient(host string, port int) *Client {
 	return &Client{
 		Client:      &http.Client{},

--- a/client_test.go
+++ b/client_test.go
@@ -215,7 +215,12 @@ func TestHappyPathCreateDatasetFromNonExistent(t *testing.T) {
 
 	tickerWaitingForVolume = 1 * time.Millisecond // TODO: this is overriding globally
 
-	s, err := c.CreateDataset(expectedDatasetName)
+	s, err := c.CreateDataset(&CreateDatasetOptions{
+		Metadata: map[string]string{
+			"name": expectedDatasetName,
+		},
+	})
+
 	assert.NoError(err)
 	assert.Equal(expectedPath, s.Path)
 }
@@ -249,7 +254,11 @@ func TestCreateDatasetThatAlreadyExists(t *testing.T) {
 	c := newFlockerTestClient(host, port)
 	assert.NoError(err)
 
-	_, err = c.CreateDataset(datasetName)
+	_, err = c.CreateDataset(&CreateDatasetOptions{
+		Metadata: map[string]string{
+			"name": datasetName,
+		},
+	})
 	assert.Equal(errVolumeAlreadyExists, err)
 }
 


### PR DESCRIPTION
This PR allow to specify custom metadata and dataset size with a new interface `CreateDS`. This allows backwards compatibility.
