### PR TITLE
Delete dataset

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -121,7 +121,6 @@ func TestFindPrimaryUUID(t *testing.T) {
 	assert.NoError(err)
 
 	c := newFlockerTestClient(host, port)
-	assert.NoError(err)
 
 	mockedPrimary = expectedPrimary
 	primary, err := c.GetPrimaryUUID()
@@ -256,7 +255,6 @@ func TestHappyPathCreateDatasetFromNonExistent(t *testing.T) {
 	assert.NoError(err)
 
 	c := newFlockerTestClient(host, port)
-	assert.NoError(err)
 
 	tickerWaitingForVolume = 1 * time.Millisecond // TODO: this is overriding globally
 
@@ -297,7 +295,6 @@ func TestCreateDatasetThatAlreadyExists(t *testing.T) {
 	assert.NoError(err)
 
 	c := newFlockerTestClient(host, port)
-	assert.NoError(err)
 
 	_, err = c.CreateDataset(&CreateDatasetOptions{
 		Metadata: map[string]string{
@@ -334,7 +331,6 @@ func TestUpdatePrimaryForDataset(t *testing.T) {
 	assert.NoError(err)
 
 	c := newFlockerTestClient(host, port)
-	assert.NoError(err)
 
 	s, err := c.UpdatePrimaryForDataset(expectedPrimary, expectedDatasetID)
 	assert.NoError(err)

--- a/client_test.go
+++ b/client_test.go
@@ -163,6 +163,51 @@ func getHostAndPortFromTestServer(ts *httptest.Server) (string, int, error) {
 	return hostSplits[0], port, nil
 }
 
+func TestDeleteDatasetExisting(t *testing.T) {
+	assert := assert.New(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("DELETE", r.Method)
+		assert.Equal("/v1/configuration/datasets/uuid1", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		b, err := json.Marshal(configurationPayload{
+			DatasetID: "uuid1",
+			Primary:   "primary1",
+			Deleted:   true,
+		})
+		assert.NoError(err)
+		w.Write(b)
+	},
+	))
+
+	host, port, err := getHostAndPortFromTestServer(ts)
+	assert.NoError(err)
+
+	c := newFlockerTestClient(host, port)
+
+	err = c.DeleteDataset("uuid1")
+	assert.NoError(err)
+}
+
+func TestDeleteDatasetNotExisting(t *testing.T) {
+	assert := assert.New(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("DELETE", r.Method)
+		assert.Equal("/v1/configuration/datasets/uuid2", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(404)
+		w.Write([]byte(`{"description": "Dataset not found."}`))
+	},
+	))
+
+	host, port, err := getHostAndPortFromTestServer(ts)
+	assert.NoError(err)
+
+	c := newFlockerTestClient(host, port)
+
+	err = c.DeleteDataset("uuid2")
+	assert.Error(err)
+}
+
 func TestHappyPathCreateDatasetFromNonExistent(t *testing.T) {
 	const (
 		expectedDatasetName = "dir"


### PR DESCRIPTION
Adds a `DeleteDataset(datasetID string) error` interface to delete volumes on the control server
